### PR TITLE
Automate release

### DIFF
--- a/.github/constants.go.template
+++ b/.github/constants.go.template
@@ -1,0 +1,16 @@
+package provider
+
+// Note This file if touched must be updated in ./github/constants.go.template
+// for release automation to work
+
+const (
+	version = "ockam_version"
+	baseURL = "https://github.com/ockam-network/ockam/releases/download/ockam_v%s/ockam.%s-%s"
+	binary  = "ockam-v" + version
+	arm64   = "arm64"
+	amd64   = "amd64"
+	aarch64 = "aarch64"
+	x86_64  = "x86_64"
+	darwin  = "darwin"
+	linux   = "linux"
+)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - v*
 
 jobs:
   test:
@@ -37,39 +35,3 @@ jobs:
       - run: go test -v -cover ./...
         env:
           TF_ACC: '1'
-
-  release:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: test
-    runs-on: ubuntu-latest
-    environment: release
-    steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2
-        with:
-          go-version: 1.18
-
-      - uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go mod download
-
-      - name: Import GPG key
-        id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@78437f97569a473e42b227be84d4084c2dfb49ba # v2.1.0
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
-
-      - uses: goreleaser/goreleaser-action@68acf3b1adf004ac9c2f0a4259e85c5f66e99bef # v2.9.1
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,134 @@
+name: Release
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Ockam tag to update homebrew to. e.g. ockam_v0.59.0
+        required: true
+    schedule:
+      - cron: '*/10 * * * *'
+
+jobs:
+  check_unique:
+    name: Check If Ockam Has An Updated Release
+    runs-on: ubuntu-20.04
+    outputs:
+      unique: ${{ steps.runner.outputs.unique }}
+      tag_name: ${{ steps.runner.outputs.tag_name }}
+
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          fetch-depth: 0
+          ref: cron_log
+
+      - uses: build-trust/.github/actions/ockam_tag_unique_check@custom-actions
+        id: runner
+
+  create_pull_request:
+    name: Create Pull Request
+    runs-on: ubuntu-20.04
+    environment: release
+    needs: check_unique
+    if: ${{ needs.check_unique.outputs.unique == 'true' }}
+    steps:
+      - name: Checkout Terraform Repo
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          fetch-depth: 0
+
+      - name: Bump Terraform Version
+        shell: bash
+        run: |
+          set -x
+          tag_name="${{ needs.check_unique.outputs.tag_name }}"
+          version_number=${tag_name:7}
+
+          temp_dir=$(mktemp -d)
+          cp .github/constants.go.template $temp_dir/constants.go
+          cd $temp_dir
+
+          sed -i "s/ockam_version/$version_number/g" constants.go
+
+          cp constants.go $GITHUB_WORKSPACE/internal/provider/constants.go
+          cat $GITHUB_WORKSPACE/internal/provider/constants.go
+
+      - name: Create Pull Request
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "bot@ockam.io"
+          git config --global user.name "Ockam Bot"
+
+          release_name="${{ needs.check_unique.outputs.tag_name }}_release_$(date +'%s')"
+          git checkout -B $release_name
+          git add $GITHUB_WORKSPACE/internal/provider/constants.go
+          git commit -m "Update version number"
+          git push --set-upstream origin $release_name
+
+          gh pr create --title "${{ needs.check_unique.outputs.tag_name }} release" --body "Ockam release"\
+           --base main -H $release_name -r mrinalwadhwa -R build-trust/terraform-provider-ockam
+
+  # Should be ran after Pull request created above is merged
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-20.04
+    environment: release
+    needs: [check_unique, create_pull_request]
+    if: ${{ needs.check_unique.outputs.unique == 'true' }}
+    steps:
+      - name: Checkout Terraform Repo
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - uses: actions/setup-go@fcdc43634adb5f7ae75a9d7a9b9361790f7293e2
+        with:
+          go-version: 1.18
+
+      - name: Create Release Context
+        id: release
+        run: |
+          tag_name="${{ needs.check_unique.outputs.tag_name }}"
+          version=${tag_name:6}
+          echo ::set-output name=version::$version
+
+      - name: Create GitHub release
+        id: release_upload_url
+        uses: actions/create-release@4c11c9fe1dcd9636620a16455165783b20fc7ea0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_name: '${{ steps.release.outputs.version }}'
+          tag_name: '${{ steps.release.outputs.version }}'
+          body: 'Ockam Terraform Provider - ${{ steps.release.outputs.version }}'
+
+      - uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - run: go mod download
+
+      - name: Import GPG key
+        id: import_gpg
+        uses: hashicorp/ghaction-import-gpg@78437f97569a473e42b227be84d4084c2dfb49ba # v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
+
+      - uses: goreleaser/goreleaser-action@68acf3b1adf004ac9c2f0a4259e85c5f66e99bef # v2.9.1
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/internal/provider/client.go
+++ b/internal/provider/client.go
@@ -46,27 +46,23 @@ func (c *Client) Read(filename string, dir string) (string, error) {
 	return strings.TrimSuffix(string(contents), "\n"), err
 }
 
-const baseURL = "https://github.com/ockam-network/ockam/releases/download/ockam_v%s/ockam.%s-%s"
-const version = "0.59.0"
-const binary = "ockam-v" + version
-
 // downloadBinary downloads the Ockam binary and places it in the user's cache.
 func downloadBinary() (string, error) {
 	var goarch string
 	var goos string
 
 	switch runtime.GOARCH {
-	case "amd64":
-		goarch = "x86_64"
-	case "arm64":
-		goarch = "aarch64"
+	case amd64:
+		goarch = x86_64
+	case arm64:
+		goarch = aarch64
 	default:
 		return "", fmt.Errorf("Arch `%s` is not supported by this provider", runtime.GOARCH)
 	}
 	switch runtime.GOOS {
-	case "darwin":
+	case darwin:
 		goos = "apple-darwin"
-	case "linux":
+	case linux:
 		goos = "unknown-linux-gnu"
 	default:
 		return "", fmt.Errorf("OS `%s` is not supported by this provider", runtime.GOOS)

--- a/internal/provider/constants.go
+++ b/internal/provider/constants.go
@@ -1,0 +1,17 @@
+package provider
+
+// Note This file if touched must be updated in ./github/constants.go.template
+// for release automation to work
+
+const (
+	version = "0.59.0"
+	baseURL = "https://github.com/ockam-network/ockam/releases/download/ockam_v%s/ockam.%s-%s"
+	binary  = "ockam-v" + version
+	arm64   = "arm64"
+	amd64   = "amd64"
+	aarch64 = "aarch64"
+	x86_64  = "x86_64"
+	darwin  = "darwin"
+
+	linux = "linux"
+)


### PR DESCRIPTION
This PR automates Ockam binary release of Terraform.
On /ockam release, CI updates Terraform repository with the latest version of Ockam binary and creates a pull request for a merge. We keep track of recent release in the cron-log branch so that we can enable branch protection feature on the main branch.