### PR TITLE
update release

### DIFF
--- a/.github/workflows/create-release-pull-request.yml
+++ b/.github/workflows/create-release-pull-request.yml
@@ -24,6 +24,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Import GPG key
+        id: import_gpg
+        uses: hashicorp/ghaction-import-gpg@78437f97569a473e42b227be84d4084c2dfb49ba
+        env:
+          GPG_PRIVATE_KEY: '${{ secrets.GPG_PRIVATE_KEY }}'
+          PASSPHRASE: '${{ secrets.GPG_PASSPHRASE }}'
+
+      - name: Add GPG Key
+        run: |
+          git config --global user.email "${{ secrets.GPG_EMAIL }}"
+          git config --global user.name "${{ secrets.GPG_USER_NAME }}"
+          git config --global user.signingkey "${{ steps.import_gpg.outputs.fingerprint }}"
+
       - name: Bump Terraform Version
         shell: bash
         run: |
@@ -48,11 +61,10 @@ jobs:
           git config --global user.email "bot@ockam.io"
           git config --global user.name "Ockam Bot"
 
-          release_name="${{ github.event.inputs.tag }}_release_$(date +'%s')"
-          git checkout -B $release_name
+          release_name="release_$(date +'%d-%m-%Y')"
+
+          # Checkout to release branch
+          git checkout -B ${release_name}
           git add $GITHUB_WORKSPACE/internal/provider/constants.go
           git commit -m "Update version number"
-          git push --set-upstream origin $release_name
-
-          gh pr create --title "${{ github.event.inputs.tag }} release" --body "Ockam release"\
-           --base main -H $release_name -r mrinalwadhwa
+          git push --set-upstream origin ${release_name}

--- a/.github/workflows/create-release-pull-request.yml
+++ b/.github/workflows/create-release-pull-request.yml
@@ -66,5 +66,5 @@ jobs:
           # Checkout to release branch
           git checkout -B ${release_name}
           git add $GITHUB_WORKSPACE/internal/provider/constants.go
-          git commit -m "Update version number"
+          git commit -S -m "Update version number"
           git push --set-upstream origin ${release_name}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,8 +65,8 @@ jobs:
         id: import_gpg
         uses: hashicorp/ghaction-import-gpg@78437f97569a473e42b227be84d4084c2dfb49ba # v2.1.0
         env:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
+          GPG_PRIVATE_KEY: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.RELEASE_GPG_PRIVATE_KEY_PASSWORD }}
 
       - uses: goreleaser/goreleaser-action@68acf3b1adf004ac9c2f0a4259e85c5f66e99bef # v2.9.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,14 @@ jobs:
 
           echo ::set-output name=version::$version
 
-      - name: Import GPG key
+      - name: Import GPG Key For Tags
+        id: tag_gpg
+        uses: hashicorp/ghaction-import-gpg@78437f97569a473e42b227be84d4084c2dfb49ba # v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.GPG_PRIVATE_KEY_PASSWORD }}
+
+      - name: Import GPG Key For Terraform
         id: import_gpg
         uses: hashicorp/ghaction-import-gpg@78437f97569a473e42b227be84d4084c2dfb49ba # v2.1.0
         env:
@@ -46,10 +53,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --global user.email "${{ secrets.RELEASE_GPG_EMAIL }}"
-          git config --global user.name "${{ secrets.RELEASE_GPG_USER_NAME }}"
-          git config --global user.signingkey "${{ steps.import_gpg.outputs.fingerprint }}"
-          git tag -s ${{ steps.release.outputs.version }}
+          git config --global user.email "${{ secrets.GPG_EMAIL }}"
+          git config --global user.name "${{ secrets.GPG_USER_NAME }}"
+          git config --global user.signingkey "${{ steps.tag_gpg.outputs.fingerprint }}"
+          git tag -s ${{ steps.release.outputs.version }} -m "Github Release"
           git push --tags
 
       - name: Create GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,23 @@ jobs:
 
           echo ::set-output name=version::$version
 
+      - name: Import GPG key
+        id: import_gpg
+        uses: hashicorp/ghaction-import-gpg@78437f97569a473e42b227be84d4084c2dfb49ba # v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.RELEASE_GPG_PRIVATE_KEY_PASSWORD }}
+
+      - name: Add GPG Key And Sign Tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.email "${{ secrets.RELEASE_GPG_EMAIL }}"
+          git config --global user.name "${{ secrets.RELEASE_GPG_USER_NAME }}"
+          git config --global user.signingkey "${{ steps.import_gpg.outputs.fingerprint }}"
+          git tag -s ${{ steps.release.outputs.version }}
+          git push --tags
+
       - name: Create GitHub release
         id: release_upload_url
         uses: actions/create-release@4c11c9fe1dcd9636620a16455165783b20fc7ea0
@@ -50,7 +67,7 @@ jobs:
           git pull
           git fetch --tags
 
-      - uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d
+      - uses: actions/cache@48af2dc4a9e8278b89d7fa154b955c30c6aaab09
         with:
           path: |
             ~/.cache/go-build
@@ -60,13 +77,6 @@ jobs:
             ${{ runner.os }}-go-
 
       - run: go mod download
-
-      - name: Import GPG key
-        id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@78437f97569a473e42b227be84d4084c2dfb49ba # v2.1.0
-        env:
-          GPG_PRIVATE_KEY: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.RELEASE_GPG_PRIVATE_KEY_PASSWORD }}
 
       - uses: goreleaser/goreleaser-action@68acf3b1adf004ac9c2f0a4259e85c5f66e99bef # v2.9.1
         with:


### PR DESCRIPTION
This PR adds ability to spawn workflow run when PRs are created by Github Action Bot. We also sign all commits using our Ockam bot GPG key.
Note, we add the following secrets which should be under Github Environment named release

- GPG_PRIVATE_KEY: Bots GPG private key
- GPG_PASSPHRASE: Bots GPG passphrase
- GPG_EMAIL: Bots GPG email
- GPG_USER_NAME: Bots GPG username

For Terraform release, we use a different GPG key
- RELEASE_GPG_PRIVATE_KEY: Terraform GPG private key
- RELEASE_GPG_PRIVATE_KEY_PASSWORD: Terraform GPG password

We also need to allow this action hashicorp/ghaction-import-gpg