### PR TITLE
Update provider example

### DIFF
--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,1 +1,9 @@
+terraform {
+  required_providers {
+    ockam = {
+      source = "build-trust/ockam"
+    }
+  }
+}
+
 provider "ockam" {}


### PR DESCRIPTION
Updating provider example with additional config which reflects the hashicorp registry address.

Because ockam provider in hashicorp registry name (url) doesn't match provider name (`ockam`) there is a need for additional configuration to make the `init` step to work.

Without this extra config, during the first `terraform init` you will get the following error:
```

Initializing the backend...

Initializing provider plugins...
- Finding latest version of hashicorp/ockam...
╷
│ Error: Failed to query available provider packages
│ 
│ Could not retrieve the list of available versions for provider hashicorp/ockam: provider registry registry.terraform.io does not have a provider named registry.terraform.io/hashicorp/ockam
│ 
│ All modules should specify their required_providers so that external consumers will get the correct providers when using a module. To see which modules are currently depending on hashicorp/ockam, run the following command:
│     terraform providers
```

I think this will be helpful for end users. This code snippet can save some time without need to browse and read through terraform docs.